### PR TITLE
Fix wrong place selected when tapping birth city suggestion

### DIFF
--- a/SoulSign/ViewModels/PlaceSearchViewModel.swift
+++ b/SoulSign/ViewModels/PlaceSearchViewModel.swift
@@ -17,6 +17,8 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
 
     private let placesClient = GMSPlacesClient.shared()
     private var cancellables = Set<AnyCancellable>()
+    // Prevents programmatic searchText changes from re-triggering a search.
+    private var suppressNextSearch = false
 
     override init() {
         super.init()
@@ -28,13 +30,27 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
             .removeDuplicates()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] query in
-                guard let self = self, !query.isEmpty else {
-                    self?.suggestions = []
+                guard let self = self else { return }
+                if self.suppressNextSearch {
+                    self.suppressNextSearch = false
+                    return
+                }
+                guard !query.isEmpty else {
+                    self.suggestions = []
                     return
                 }
                 self.fetchPlacePredictions(for: query)
             }
             .store(in: &cancellables)
+    }
+
+    func selectPrediction(_ prediction: GMSAutocompletePrediction) {
+        let displayText = prediction.attributedFullText.string
+        suppressNextSearch = true
+        searchText = displayText
+        selectedPlaceName = displayText
+        suggestions = []
+        fetchCoordinates(for: prediction)
     }
 
     private func fetchPlacePredictions(for query: String) {
@@ -50,7 +66,7 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
         }
     }
 
-    func fetchCoordinates(for prediction: GMSAutocompletePrediction) {
+    private func fetchCoordinates(for prediction: GMSAutocompletePrediction) {
         let placeID = prediction.placeID
         let fields: GMSPlaceField = [.coordinate, .name, .formattedAddress]
 
@@ -62,8 +78,11 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
             guard let place = place else { return }
             DispatchQueue.main.async {
                 self?.selectedCoordinates = place.coordinate
-                self?.selectedPlaceName = place.formattedAddress ?? place.name ?? ""
-                self?.searchText = self?.selectedPlaceName ?? ""
+                let resolvedName = place.formattedAddress ?? place.name ?? ""
+                self?.selectedPlaceName = resolvedName
+                // Update the text field to the resolved address without triggering a new search.
+                self?.suppressNextSearch = true
+                self?.searchText = resolvedName
             }
         }
     }

--- a/SoulSign/Views/BirthPlaceSuggestionsView.swift
+++ b/SoulSign/Views/BirthPlaceSuggestionsView.swift
@@ -27,11 +27,7 @@ struct BirthPlaceSuggestionsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(placeVM.suggestions, id: \ .placeID) { prediction in
                         Button(action: {
-                            let selectedText = prediction.attributedFullText.string
-                            placeVM.searchText = selectedText
-                            placeVM.selectedPlaceName = selectedText
-                            placeVM.suggestions = []
-                            placeVM.fetchCoordinates(for: prediction)
+                            placeVM.selectPrediction(prediction)
                         }) {
                             Text(prediction.attributedFullText.string)
                                 .foregroundColor(.white)


### PR DESCRIPTION
## What's wrong

Tapping a suggestion from the autocomplete list could result in the wrong city's coordinates being stored. The bug is a race condition with two triggers:

1. **First trigger:** setting `searchText` on tap re-arms the debounced Combine pipeline. After 300 ms, `fetchPlacePredictions` fires again with the selected text and repopulates the suggestions list with potentially different results.
2. **Second trigger:** when `fetchCoordinates` completes, it writes the resolved formatted address back to `searchText` (e.g. `"Amsterdam, Noord-Holland, Netherlands"` instead of `"Amsterdam, Netherlands"`). This is a new value that passes through `removeDuplicates()`, firing the pipeline a third time — so `selectedCoordinates` could end up belonging to whichever suggestion that search resolved last, not what the user actually tapped.

## Fix

**`PlaceSearchViewModel`**
- Added `suppressNextSearch: Bool` flag. The Combine sink checks the flag and skips the search (then resets it) whenever a programmatic `searchText` write is in flight.
- Added `selectPrediction(_ prediction:)` as the single public entry point for user-driven selection — sets the flag, updates state, clears suggestions, and kicks off coordinate resolution.
- Made `fetchCoordinates` private; it also sets `suppressNextSearch = true` before writing the resolved address back to `searchText`.

**`BirthPlaceSuggestionsView`**
- Button action replaced with a single call to `placeVM.selectPrediction(prediction)` instead of directly mutating VM properties.

## Testing

- [ ] Type a city, tap a suggestion — text field shows the selected city, no suggestion list reappears
- [ ] Tap a suggestion and verify the coordinates stored match the tapped city (check via debugger or a visible lat/lon display)
- [ ] Type a new query after a successful selection — autocomplete works normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)