### PR TITLE
Adaptive dark/light mode for all views

### DIFF
--- a/SoulSign/ContentView.swift
+++ b/SoulSign/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @StateObject private var viewModel = SoulSignViewModel()
     @State private var showAffirmations = false
     @EnvironmentObject var notificationRouter: NotificationRouter
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var body: some View {
         NavigationStack {
@@ -36,10 +38,10 @@ struct ContentView: View {
                             Text("✨ Your SoulSign Reading")
                                 .font(.title)
                                 .fontWeight(.bold)
-                                .foregroundColor(.white)
+                                .foregroundColor(theme.primaryText)
 
                             Text(viewModel.chartResult)
-                                .foregroundColor(.white)
+                                .foregroundColor(theme.primaryText)
                                 .font(.body)
                                 .multilineTextAlignment(.leading)
 
@@ -49,8 +51,8 @@ struct ContentView: View {
                                 }
                                 .frame(maxWidth: .infinity)
                                 .padding()
-                                .background(Color.white.opacity(0.9))
-                                .foregroundColor(.purple)
+                                .background(theme.primaryButtonBg)
+                                .foregroundColor(theme.primaryButtonText)
                                 .cornerRadius(12)
 
                                 Button("🌞 Daily Affirmations") {
@@ -58,8 +60,8 @@ struct ContentView: View {
                                 }
                                 .frame(maxWidth: .infinity)
                                 .padding()
-                                .background(Color.white.opacity(0.9))
-                                .foregroundColor(.blue)
+                                .background(theme.secondaryButtonBg)
+                                .foregroundColor(theme.secondaryButtonText)
                                 .cornerRadius(12)
                             }
                         }
@@ -70,8 +72,8 @@ struct ContentView: View {
                 if viewModel.isLoading {
                     VStack {
                         ProgressView("Generating Chart...")
-                            .progressViewStyle(CircularProgressViewStyle(tint: .black))
-                            .foregroundColor(.black)
+                            .progressViewStyle(CircularProgressViewStyle(tint: theme.primaryText))
+                            .foregroundColor(theme.primaryText)
                             .padding()
                     }
                 }
@@ -86,7 +88,7 @@ struct ContentView: View {
                 DailyAffirmationView()
             }
             .toolbarBackground(Color.clear, for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarColorScheme(theme.navColorScheme, for: .navigationBar)
             .navigationTitle("SoulSign")
             .onAppear {
                 requestNotificationPermission()

--- a/SoulSign/Theme.swift
+++ b/SoulSign/Theme.swift
@@ -1,0 +1,44 @@
+//
+//  Theme.swift
+//  SoulSign
+//
+import SwiftUI
+
+struct AppTheme {
+    let colorScheme: ColorScheme
+    private var isDark: Bool { colorScheme == .dark }
+
+    // MARK: - Background
+    var backgroundColors: [Color] {
+        isDark
+            ? [.black, .blue.opacity(0.6), .purple]
+            : [Color(red: 0.97, green: 0.95, blue: 1.00),
+               Color(red: 0.80, green: 0.72, blue: 0.96),
+               Color(red: 0.55, green: 0.35, blue: 0.85)]
+    }
+
+    var sparkleOpacity: Double { isDark ? 0.30 : 0.15 }
+
+    // MARK: - Text
+    var primaryText: Color   { isDark ? .white        : Color(red: 0.18, green: 0.08, blue: 0.38) }
+    var secondaryText: Color { isDark ? .white.opacity(0.85) : Color(red: 0.30, green: 0.18, blue: 0.50) }
+    var fieldText: Color     { isDark ? .white        : Color(red: 0.18, green: 0.08, blue: 0.38) }
+
+    // MARK: - Cards
+    var cardBackground: Color { isDark ? .white.opacity(0.12) : .white }
+    var cardText: Color       { isDark ? .white               : Color(red: 0.18, green: 0.08, blue: 0.38) }
+
+    // MARK: - Buttons
+    var primaryButtonBg: Color     { isDark ? .white                              : Color(red: 0.45, green: 0.18, blue: 0.78) }
+    var primaryButtonText: Color   { isDark ? Color(red: 0.45, green: 0.18, blue: 0.78) : .white }
+    var secondaryButtonBg: Color   { isDark ? .white.opacity(0.88)                : Color(red: 0.25, green: 0.08, blue: 0.58) }
+    var secondaryButtonText: Color { isDark ? .blue                               : .white }
+
+    // MARK: - Place suggestions
+    var suggestionText: Color   { isDark ? .white              : Color(red: 0.18, green: 0.08, blue: 0.38) }
+    var suggestionRowBg: Color  { isDark ? .white.opacity(0.1) : .purple.opacity(0.10) }
+    var suggestionListBg: Color { isDark ? .black.opacity(0.3) : .white.opacity(0.85) }
+
+    // MARK: - Navigation bar
+    var navColorScheme: ColorScheme { isDark ? .dark : .light }
+}

--- a/SoulSign/Views/BirthPlaceSuggestionsView.swift
+++ b/SoulSign/Views/BirthPlaceSuggestionsView.swift
@@ -9,38 +9,40 @@ import GooglePlaces
 
 struct BirthPlaceSuggestionsView: View {
     @ObservedObject var placeVM: PlaceSearchViewModel
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             TextField("City, Country", text: $placeVM.searchText)
-                .foregroundColor(.black)
+                .foregroundColor(theme.fieldText)
                 .autocapitalization(.words)
                 .padding(10)
                 .background(Color.clear)
                 .overlay(
                     RoundedRectangle(cornerRadius: 2)
-                        .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                        .stroke(theme.primaryText.opacity(0.3), lineWidth: 1)
                 )
                 .multilineTextAlignment(.leading)
 
             if !placeVM.suggestions.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {
-                    ForEach(placeVM.suggestions, id: \ .placeID) { prediction in
+                    ForEach(placeVM.suggestions, id: \.placeID) { prediction in
                         Button(action: {
                             placeVM.selectPrediction(prediction)
                         }) {
                             Text(prediction.attributedFullText.string)
-                                .foregroundColor(.white)
+                                .foregroundColor(theme.suggestionText)
                                 .padding(.vertical, 6)
                                 .padding(.horizontal, 8)
-                                .background(Color.white.opacity(0.1))
+                                .background(theme.suggestionRowBg)
                                 .cornerRadius(8)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
                 }
                 .padding(.vertical, 4)
-                .background(Color.black.opacity(0.3))
+                .background(theme.suggestionListBg)
                 .cornerRadius(12)
             }
         }

--- a/SoulSign/Views/DailyAffirmationView.swift
+++ b/SoulSign/Views/DailyAffirmationView.swift
@@ -11,6 +11,8 @@ struct DailyAffirmationView: View {
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var forceRefresh = false
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var body: some View {
         NavigationView {
@@ -22,19 +24,19 @@ struct DailyAffirmationView: View {
                         Text("Daily Affirmations")
                             .font(.largeTitle)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(theme.primaryText)
                             .padding(.bottom, 10)
 
                         if isLoading {
                             ProgressView("Loading Affirmations...")
-                                .foregroundColor(.white)
+                                .foregroundColor(theme.primaryText)
                         } else if let affirmations = affirmations {
-                            affirmationBlock(title: "💰 Finance", text: affirmations.Finance)
-                            affirmationBlock(title: "❤️ Love", text: affirmations.Love)
+                            affirmationBlock(title: "💰 Finance",     text: affirmations.Finance)
+                            affirmationBlock(title: "❤️ Love",        text: affirmations.Love)
                             affirmationBlock(title: "🧘 Mind & Spirit", text: affirmations.MindSpirit)
-                            affirmationBlock(title: "💼 Career", text: affirmations.Career)
-                            affirmationBlock(title: "🤝 Friendship", text: affirmations.Friendship)
-                            affirmationBlock(title: "🩺 Health", text: affirmations.Health)
+                            affirmationBlock(title: "💼 Career",      text: affirmations.Career)
+                            affirmationBlock(title: "🤝 Friendship",  text: affirmations.Friendship)
+                            affirmationBlock(title: "🩺 Health",      text: affirmations.Health)
                         } else if let errorMessage = errorMessage {
                             Text(errorMessage)
                                 .foregroundColor(.red)
@@ -46,8 +48,8 @@ struct DailyAffirmationView: View {
                         }
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.white.opacity(0.9))
-                        .foregroundColor(.blue)
+                        .background(theme.secondaryButtonBg)
+                        .foregroundColor(theme.secondaryButtonText)
                         .cornerRadius(12)
                     }
                     .padding()
@@ -82,13 +84,16 @@ struct DailyAffirmationView: View {
         VStack(alignment: .leading) {
             Text(title)
                 .font(.headline)
+                .foregroundColor(theme.cardText)
             Text("\"\(text)\"")
                 .font(.body)
                 .italic()
+                .foregroundColor(theme.cardText)
         }
         .padding()
-        .background(Color.white.opacity(0.9))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.cardBackground)
         .cornerRadius(10)
-        .shadow(radius: 2)
+        .shadow(color: .black.opacity(0.1), radius: 2)
     }
 }

--- a/SoulSign/Views/NightSkyBackground.swift
+++ b/SoulSign/Views/NightSkyBackground.swift
@@ -8,10 +8,13 @@
 import SwiftUI
 
 struct NightSkyBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
+        let theme = AppTheme(colorScheme: colorScheme)
         ZStack {
             LinearGradient(
-                gradient: Gradient(colors: [Color.black, Color.blue.opacity(0.6), Color.purple]),
+                gradient: Gradient(colors: theme.backgroundColors),
                 startPoint: .top,
                 endPoint: .bottom
             )
@@ -19,7 +22,7 @@ struct NightSkyBackground: View {
 
             LottieView(filename: "sparkles")
                 .ignoresSafeArea()
-                .opacity(0.3)
+                .opacity(theme.sparkleOpacity)
         }
     }
 }

--- a/SoulSign/Views/UserInputView.swift
+++ b/SoulSign/Views/UserInputView.swift
@@ -13,6 +13,8 @@ struct UserInputView: View {
     @State private var birthDate: Date = Date()
     @State private var birthTime: Date = Date()
     @StateObject private var placeVM = PlaceSearchViewModel()
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var onSubmit: (_ fullName: String, _ birthDate: Date, _ birthTime: Date, _ birthPlace: String, _ coordinates: CLLocationCoordinate2D?) -> Void
 
@@ -22,26 +24,25 @@ struct UserInputView: View {
                 NightSkyBackground()
 
                 Form {
-                    Section(header: Text("Personal Info").foregroundColor(.white)) {
+                    Section(header: Text("Personal Info").foregroundColor(theme.primaryText)) {
                         TextField("Full Name", text: $fullName)
                             .autocapitalization(.words)
                             .multilineTextAlignment(.leading)
-                            .foregroundColor(.black)
-                            .accentColor(.black)
+                            .foregroundColor(theme.fieldText)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
-                    Section(header: Text("Birth Date").foregroundColor(.white)) {
+                    Section(header: Text("Birth Date").foregroundColor(theme.primaryText)) {
                         DatePicker("Select Date", selection: $birthDate, displayedComponents: .date)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
-                    Section(header: Text("Birth Time").foregroundColor(.white)) {
+                    Section(header: Text("Birth Time").foregroundColor(theme.primaryText)) {
                         DatePicker("Select Time", selection: $birthTime, displayedComponents: .hourAndMinute)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
-                    Section(header: Text("Birth Place").foregroundColor(.white)) {
+                    Section(header: Text("Birth Place").foregroundColor(theme.primaryText)) {
                         BirthPlaceSuggestionsView(placeVM: placeVM)
                     }
 
@@ -65,14 +66,12 @@ struct UserInputView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.clear, for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarColorScheme(theme.navColorScheme, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    let titleText = Text("Enter Birth Details")
-                        .foregroundColor(.white)
+                    Text("Enter Birth Details")
+                        .foregroundColor(theme.primaryText)
                         .font(.largeTitle.weight(.bold))
-
-                    titleText
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.leading)
                 }

--- a/SoulSign/Views/WelcomeView.swift
+++ b/SoulSign/Views/WelcomeView.swift
@@ -6,18 +6,20 @@
 //
 
 import SwiftUI
-//import MapKit
-//import Combine
 
 struct WelcomeView: View {
     @AppStorage("hasSeenWelcome") private var hasSeenWelcome = false
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var body: some View {
         ZStack {
             NightSkyBackground()
+
+            // Extra sparkle layer on welcome screen
             LottieView(filename: "sparkles")
                 .ignoresSafeArea()
-                .opacity(0.3)
+                .opacity(theme.sparkleOpacity)
 
             VStack(spacing: 30) {
                 Spacer()
@@ -30,11 +32,11 @@ struct WelcomeView: View {
                 Text("🌌 Welcome to SoulSign")
                     .font(.largeTitle)
                     .fontWeight(.bold)
-                    .foregroundColor(.white)
+                    .foregroundColor(theme.primaryText)
 
                 Text("Discover your cosmic blueprint.\nExplore your soul's story through the stars.")
                     .font(.title3)
-                    .foregroundColor(.white.opacity(0.9))
+                    .foregroundColor(theme.secondaryText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
@@ -47,8 +49,8 @@ struct WelcomeView: View {
                         .font(.headline)
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.white)
-                        .foregroundColor(.purple)
+                        .background(theme.primaryButtonBg)
+                        .foregroundColor(theme.primaryButtonText)
                         .cornerRadius(12)
                         .padding(.horizontal)
                 }


### PR DESCRIPTION
## What changed

Adds `Theme.swift` — a single `AppTheme` struct that translates `ColorScheme` into a consistent token set (text, background, cards, buttons, suggestions). Every view reads `@Environment(\.colorScheme)` and derives its colors from `AppTheme`, so the whole app reacts automatically when the user toggles their device appearance setting.

### Dark mode (unchanged feel)
Night sky gradient (black → blue → purple), white text, translucent white cards, white-fill buttons with purple text.

### Light mode (new)
Soft lavender-to-purple dawn gradient, deep-purple text, white cards, purple-fill buttons with white text.

## Files changed

| File | What changed |
|---|---|
| `Theme.swift` (**new**) | `AppTheme` struct with all color tokens |
| `NightSkyBackground` | Adaptive gradient + sparkle opacity |
| `WelcomeView` | Title, subtitle, button |
| `UserInputView` | Section headers, text field, toolbar color scheme |
| `BirthPlaceSuggestionsView` | Field text, suggestion row/list |
| `ContentView` | Chart text, buttons, progress indicator, toolbar |
| `DailyAffirmationView` | Title, cards (bg + text), refresh button; also fixes pre-existing white-on-white contrast bug in dark mode |

## Test plan

- [ ] Run on device/simulator in **dark mode** — all screens look identical to before
- [ ] Switch device to **light mode** — gradient becomes lavender/dawn, text is dark purple, buttons are purple-filled
- [ ] Toggle appearance mid-session — all views update instantly with no layout jumps
- [ ] Place suggestions dropdown readable in both modes
- [ ] Affirmation cards readable in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)