### PR TITLE
Fix place selection: stop writing searchText from fetchCoordinates

### DIFF
--- a/SoulSign/ViewModels/PlaceSearchViewModel.swift
+++ b/SoulSign/ViewModels/PlaceSearchViewModel.swift
@@ -17,7 +17,6 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
 
     private let placesClient = GMSPlacesClient.shared()
     private var cancellables = Set<AnyCancellable>()
-    // Prevents programmatic searchText changes from re-triggering a search.
     private var suppressNextSearch = false
 
     override init() {
@@ -46,6 +45,7 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
 
     func selectPrediction(_ prediction: GMSAutocompletePrediction) {
         let displayText = prediction.attributedFullText.string
+        // Suppress the one debounce that fires from setting searchText below.
         suppressNextSearch = true
         searchText = displayText
         selectedPlaceName = displayText
@@ -62,7 +62,9 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
                 print("Autocomplete error: \(error.localizedDescription)")
                 return
             }
-            self?.suggestions = results ?? []
+            DispatchQueue.main.async {
+                self?.suggestions = results ?? []
+            }
         }
     }
 
@@ -78,13 +80,12 @@ final class PlaceSearchViewModel: NSObject, ObservableObject {
             guard let place = place else { return }
             DispatchQueue.main.async {
                 self?.selectedCoordinates = place.coordinate
-                let resolvedName = place.formattedAddress ?? place.name ?? ""
-                self?.selectedPlaceName = resolvedName
-                // Update the text field to the resolved address without triggering a new search.
-                self?.suppressNextSearch = true
-                self?.searchText = resolvedName
+                // Only update selectedPlaceName — do NOT touch searchText.
+                // Writing searchText here caused a second debounce that raced
+                // with the first suppress and re-triggered the search, making
+                // it impossible to keep a selection.
+                self?.selectedPlaceName = place.formattedAddress ?? place.name ?? ""
             }
         }
     }
 }
-


### PR DESCRIPTION
## Root cause

`fetchCoordinates` was updating `searchText` to the resolved formatted address after the API returned (e.g. `"Amsterdam, Noord-Holland, Netherlands"` after the user tapped `"Amsterdam, Netherlands"`). This triggered a **second debounce**.

The race: when the Places API responds in under 300 ms, the first `suppressNextSearch = true` flag (set by `selectPrediction`) gets consumed by the first debounce. The second debounce then fires with the flag already reset to `false`, calls `fetchPlacePredictions`, and repopulates the suggestion list. The dropdown re-appears immediately after every tap, making it impossible to keep a selection.

## Fix

`fetchCoordinates` now only updates `selectedCoordinates` and `selectedPlaceName` (the values actually used by chart submission). It no longer touches `searchText`. The text field stays at whatever the user tapped, which is a clear enough label.

The `suppressNextSearch` flag now only needs to handle the single, predictable debounce from `selectPrediction`'s `searchText = displayText` write — no timing ambiguity.

## Testing

- [ ] Type a city, tap a suggestion — dropdown closes and stays closed
- [ ] The text field shows the tapped city name
- [ ] "Read My Chart" button enables after selection
- [ ] Typing a new search after selection works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)