### PR TITLE
Fix wrong suggestion selected: move dropdown outside Form

### DIFF
--- a/SoulSign/Views/BirthPlaceSuggestionsView.swift
+++ b/SoulSign/Views/BirthPlaceSuggestionsView.swift
@@ -1,50 +1,58 @@
-//  BirthPlaceSuggestionView.swift
+//  BirthPlaceSuggestionsView.swift
 //  SoulSign
 //
 //  Created by Marina Dedikova on 07/06/2025.
 //
-// BirthPlaceSuggestionsView.swift
 import SwiftUI
 import GooglePlaces
 
-struct BirthPlaceSuggestionsView: View {
+/// The text field that lives inside the Form cell.
+struct BirthPlaceTextField: View {
     @ObservedObject var placeVM: PlaceSearchViewModel
     @Environment(\.colorScheme) private var colorScheme
     private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            TextField("City, Country", text: $placeVM.searchText)
-                .foregroundColor(theme.fieldText)
-                .autocapitalization(.words)
-                .padding(10)
-                .background(Color.clear)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(theme.primaryText.opacity(0.3), lineWidth: 1)
-                )
-                .multilineTextAlignment(.leading)
+        TextField("City, Country", text: $placeVM.searchText)
+            .foregroundColor(theme.fieldText)
+            .autocapitalization(.words)
+            .multilineTextAlignment(.leading)
+    }
+}
 
-            if !placeVM.suggestions.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(placeVM.suggestions, id: \.placeID) { prediction in
-                        Button(action: {
-                            placeVM.selectPrediction(prediction)
-                        }) {
-                            Text(prediction.attributedFullText.string)
-                                .foregroundColor(theme.suggestionText)
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 8)
-                                .background(theme.suggestionRowBg)
-                                .cornerRadius(8)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
+/// The dropdown that floats in the ZStack — NOT inside the Form — so
+/// UITableView's stale hit-test rects never interfere with tap targets.
+struct BirthPlaceSuggestionsDropdown: View {
+    @ObservedObject var placeVM: PlaceSearchViewModel
+    @Environment(\.colorScheme) private var colorScheme
+    private var theme: AppTheme { AppTheme(colorScheme: colorScheme) }
+
+    var body: some View {
+        if !placeVM.suggestions.isEmpty {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(placeVM.suggestions, id: \.placeID) { prediction in
+                    Button {
+                        placeVM.selectPrediction(prediction)
+                    } label: {
+                        Text(prediction.attributedFullText.string)
+                            .foregroundColor(theme.suggestionText)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    // Explicit tappable area — avoids hit-test ambiguity
+                    .contentShape(Rectangle())
+
+                    if prediction.placeID != placeVM.suggestions.last?.placeID {
+                        Divider().background(theme.suggestionText.opacity(0.2))
                     }
                 }
-                .padding(.vertical, 4)
-                .background(theme.suggestionListBg)
-                .cornerRadius(12)
             }
+            .background(theme.suggestionListBg)
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            .padding(.horizontal)
         }
     }
 }

--- a/SoulSign/Views/UserInputView.swift
+++ b/SoulSign/Views/UserInputView.swift
@@ -20,7 +20,7 @@ struct UserInputView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
+            ZStack(alignment: .top) {
                 NightSkyBackground()
 
                 Form {
@@ -43,7 +43,10 @@ struct UserInputView: View {
                     }
 
                     Section(header: Text("Birth Place").foregroundColor(theme.primaryText)) {
-                        BirthPlaceSuggestionsView(placeVM: placeVM)
+                        // Only the text field lives inside the Form — the dropdown
+                        // is rendered in the ZStack above to avoid UITableView
+                        // hit-test issues that cause the wrong row to be selected.
+                        BirthPlaceTextField(placeVM: placeVM)
                     }
 
                     Section {
@@ -63,6 +66,14 @@ struct UserInputView: View {
                 .scrollContentBackground(.hidden)
                 .background(Color.clear)
                 .environment(\.locale, Locale(identifier: "en_US"))
+
+                // Suggestions dropdown floats over the Form in the ZStack.
+                // Vertical offset positions it roughly below the Birth Place row.
+                VStack {
+                    Spacer().frame(height: 310)
+                    BirthPlaceSuggestionsDropdown(placeVM: placeVM)
+                    Spacer()
+                }
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.clear, for: .navigationBar)


### PR DESCRIPTION
## Root cause

The suggestion buttons were rendered inside a `Form` cell, which is backed by `UITableView`. UIKit computes hit-test rects for each cell **once**, before the cell's content dynamically expands to show the suggestion list. When the dropdown appeared, the cell's registered hit area was still sized for just the `TextField`. Tapping what visually appeared to be the **first** suggestion landed at the bottom of the stale hit-test rect — which mapped to the **last** item.

## Fix

Split `BirthPlaceSuggestionsView` into two components:

| Component | Location | Purpose |
|---|---|---|
| `BirthPlaceTextField` | Inside `Form` cell | Just the search text field |
| `BirthPlaceSuggestionsDropdown` | ZStack above the Form | The floating dropdown list |

By placing the dropdown in a plain `ZStack`, SwiftUI's own hit-testing handles all taps — no UITableView coordinate translation involved. Also added `.buttonStyle(.plain)` and `.contentShape(Rectangle())` to each row for unambiguous touch targets.

## Testing

- [ ] Type a city, tap the **first** suggestion — correct city is selected
- [ ] Tap the **last** suggestion — correct city is selected  
- [ ] Tap any middle suggestion — correct city is selected
- [ ] Dropdown closes after any selection
- [ ] Typing after a selection brings up fresh suggestions normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)