### PR TITLE
Remove AI-indicator phrases from chart readings

### DIFF
--- a/SoulSign/ViewModels/SoulSignViewModel.swift
+++ b/SoulSign/ViewModels/SoulSignViewModel.swift
@@ -48,6 +48,8 @@ final class SoulSignViewModel: ObservableObject {
         Place of Birth: \(birthPlace)\(coordNote)
 
         Focus on personality traits, soul purpose, life path, and any meaningful planetary alignments. Use warm, beginner-friendly language.
+
+        Important: write the reading as a self-contained piece, like a letter or a personal report addressed to \(fullName). Do not include any closing offers, invitations to ask questions, suggestions to explore further, or any phrase that implies an AI or assistant is available for follow-up. End the reading naturally — with an inspiring or reflective closing sentence — not with a call to action or an open-ended question.
         """
 
         let messages = [


### PR DESCRIPTION
## Problem

The chart reading generated by OpenAI would end with typical LLM assistant phrases like:
- *"Feel free to ask if you'd like to explore any aspect further!"*
- *"Let me know if you have any questions."*
- *"Would you like me to dive deeper into any of these areas?"*

These break the immersion of a personal astrological reading and make it obvious the text was AI-generated.

## Fix

Added explicit instructions to the prompt:
- Write as a self-contained personal report / letter addressed to the user by name
- No closing offers, invitations to ask questions, or suggestions to explore further
- No phrases implying an AI or assistant is available for follow-up
- End with an inspiring or reflective closing sentence — not a call to action

🤖 Generated with [Claude Code](https://claude.com/claude-code)